### PR TITLE
Shot order of general

### DIFF
--- a/apps/scouting/frontend/src/strategy/GeneralDataTable.tsx
+++ b/apps/scouting/frontend/src/strategy/GeneralDataTable.tsx
@@ -97,10 +97,10 @@ export const GeneralDataTable: React.FC<GeneralDataTableProps> = ({
         ),
       }),
 
-      createColumn("shot", "text-slate-300 font-medium"),
       createColumn("scored", "text-emerald-400 font-bold"),
       createColumn("missed", "text-rose-500/90 font-medium"),
       createColumn("passed", "text-orange-400 font-medium"),
+      createColumn("shot", "text-slate-300 font-medium"),
     ],
     [gameTime],
   );


### PR DESCRIPTION
moved the shot column to the end of the table instead of the beginning
<img width="1886" height="503" alt="image" src="https://github.com/user-attachments/assets/2167bbaf-f707-4a33-8a5a-1b49f74d426e" />
